### PR TITLE
Mobile nav re-work

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -40,15 +40,11 @@ function SectionLink({ href, name: section, subsections }: { href: string; name:
 	const [open, setOpen] = useState(false);
 	return (
 		<div className="section-link">
-			<Link href={href}>
+			<Link href={href} onClick={e => { e.preventDefault(); setOpen(!open); }}>
 				{section}
 				{subsections && (
 					<i
 						className="fa-solid fa-chevron-down"
-						onClick={e => {
-							e.preventDefault();
-							setOpen(!open);
-						}}
 						data-open={open}
 					/>
 				)}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -22,7 +22,7 @@ type Subsection = {
 	href: string;
 };
 
-function SectionLink({ href, name: section, subsections }: { href: string; name: string; subsections?: Subsection[]; isMobile: boolean }) {
+function SectionLink({ href, name: section, subsections }: { href: string; name: string; subsections?: Subsection[]}) {
 	const [open, setOpen] = useState(false);
 	return (
 		<div className="section-link">

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -22,20 +22,6 @@ type Subsection = {
 	href: string;
 };
 
-function useIsMobileWidth() {
-	const maxWidth = 970
-	const [isMobile, setIsMobile] = useState(() => (typeof window !== "undefined" ? window.innerWidth <= maxWidth : false));
-
-	useEffect(() => {
-		if (typeof window === "undefined") return;
-		const handleResize = () => setIsMobile(window.innerWidth <= maxWidth);
-		handleResize();
-		window.addEventListener("resize", handleResize);
-		return () => window.removeEventListener("resize", handleResize);
-	}, [maxWidth]);
-
-	return isMobile;
-}
 function SectionLink({ href, name: section, subsections }: { href: string; name: string; subsections?: Subsection[]; isMobile: boolean }) {
 	const [open, setOpen] = useState(false);
 	return (
@@ -45,68 +31,8 @@ function SectionLink({ href, name: section, subsections }: { href: string; name:
 				{ subsections && <div className="bar-vertical"/> }
 				{ subsections && <span onClick={e => { e.preventDefault(); setOpen(!open); }}><i className="fa-solid fa-chevron-down" data-open={open}/></span> }
 			</div>
-			{/* <Link href={href} onClick={e => { e.preventDefault(); setOpen(!open); }}>
-				{section}
-				{subsections && (
-					<i
-						className="fa-solid fa-chevron-down"
-						data-open={open}
-					/>
-				)}
-			</Link> */}
 			{subsections && (
 				<div className="dropdown">
-					{subsections.map((subsection, i) => (
-						<Link key={i} href={subsection.href}>
-							{subsection.name}
-						</Link>
-					))}
-				</div>
-			)}
-		</div>
-	);
-}
-
-function SectionLinkA({ href, name: section, subsections, isMobile }: { href: string; name: string; subsections?: Subsection[]; isMobile: boolean }) {
-	const [open, setOpen] = useState(false);
-	const hasDropdown = Boolean(subsections?.length);
-
-	useEffect(() => {
-		if (!isMobile) setOpen(false);
-	}, [isMobile]);
-
-	const handleTopClick = (e: MouseEvent<HTMLAnchorElement>) => {
-		if (isMobile && hasDropdown) {
-			e.preventDefault();
-			setOpen(prev => !prev);
-		}
-	};
-
-	return (
-		<div className="section-link" data-open={open ? "true" : "false"}>
-			<Link href={href} onClick={handleTopClick}>
-				{section}
-				{hasDropdown && isMobile && (
-					<i
-						className="fa-solid fa-chevron-down"
-						onClick={e => {
-							e.preventDefault();
-							e.stopPropagation(); // <-- avoid double toggle from the Link
-							setOpen(prev => !prev);
-						}}
-						data-open={open}
-						aria-hidden="true"
-					/>
-				)}
-				{hasDropdown && !isMobile && <i className="fa-solid fa-chevron-down" aria-hidden="true" />}
-			</Link>
-			{subsections && (
-				<div className="dropdown">
-					{isMobile && (
-						<Link href={href} className="category-self">
-							{section}
-						</Link>
-					)}
 					{subsections.map((subsection, i) => (
 						<Link key={i} href={subsection.href}>
 							{subsection.name}
@@ -119,8 +45,6 @@ function SectionLinkA({ href, name: section, subsections, isMobile }: { href: st
 }
 
 export function Nav() {
-	const isMobile = useIsMobileWidth();
-
 	return (
 		<nav>
 			<Masthead />
@@ -129,9 +53,8 @@ export function Nav() {
 					href="/category/news-features"
 					name="NEWS & FEATURES"
 					subsections={[{ name: "PHS Profiles", href: "/category/news-features/phs-profiles" }]}
-					isMobile={isMobile}
 				/>
-				<SectionLink href="/category/multimedia" name="MULTIMEDIA" isMobile={isMobile} />
+				<SectionLink href="/category/multimedia" name="MULTIMEDIA" />
 				<SectionLink
 					href="/category/opinions"
 					name="OPINIONS"
@@ -139,20 +62,17 @@ export function Nav() {
 						{ name: "Editorials", href: "/category/opinions/editorials" },
 						{ name: "Cheers & Jeers", href: "/category/opinions/cheers-jeers" },
 					]}
-					isMobile={isMobile}
 				/>
-				<SectionLink href="/category/vanguard" name="VANGUARD" isMobile={isMobile} />
+				<SectionLink href="/category/vanguard" name="VANGUARD" />
 				<SectionLink
 					href="/category/arts-entertainment"
 					name="ARTS & ENTERTAINMENT"
 					subsections={[{ name: "Student Artists", href: "/category/arts-entertainment/student-artists" }]}
-					isMobile={isMobile}
 				/>
 				<SectionLink
 					href="/category/sports"
 					name="SPORTS"
 					subsections={[{ name: "Student Athletes", href: "/category/sports/student-athletes" }]}
-					isMobile={isMobile}
 				/>
 				<SectionLink
 					href="/about"
@@ -163,9 +83,8 @@ export function Nav() {
 						{ name: "2023 Staff", href: "/about/2023" },
 						{ name: "2022 Staff", href: "/about/2022" },
 					]}
-					isMobile={isMobile}
 				/>
-				<SectionLink href="/archives" name="ARCHIVES" isMobile={isMobile} />
+				<SectionLink href="/archives" name="ARCHIVES" />
 			</div>
 		</nav>
 	);

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -40,7 +40,12 @@ function SectionLink({ href, name: section, subsections }: { href: string; name:
 	const [open, setOpen] = useState(false);
 	return (
 		<div className="section-link">
-			<Link href={href} onClick={e => { e.preventDefault(); setOpen(!open); }}>
+			<div className="section-button">
+				<Link href={href}>{section}</Link>
+				{ subsections && <div className="bar-vertical"/> }
+				{ subsections && <i className="fa-solid fa-chevron-down" data-open={open} onClick={e => { e.preventDefault(); setOpen(!open); }}/> }
+			</div>
+			{/* <Link href={href} onClick={e => { e.preventDefault(); setOpen(!open); }}>
 				{section}
 				{subsections && (
 					<i
@@ -48,7 +53,7 @@ function SectionLink({ href, name: section, subsections }: { href: string; name:
 						data-open={open}
 					/>
 				)}
-			</Link>
+			</Link> */}
 			{subsections && (
 				<div className="dropdown">
 					{subsections.map((subsection, i) => (

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -22,7 +22,8 @@ type Subsection = {
 	href: string;
 };
 
-function useIsMobileWidth(maxWidth = 970) {
+function useIsMobileWidth() {
+	const maxWidth = 970
 	const [isMobile, setIsMobile] = useState(() => (typeof window !== "undefined" ? window.innerWidth <= maxWidth : false));
 
 	useEffect(() => {
@@ -35,8 +36,37 @@ function useIsMobileWidth(maxWidth = 970) {
 
 	return isMobile;
 }
+function SectionLink({ href, name: section, subsections }: { href: string; name: string; subsections?: Subsection[]; isMobile: boolean }) {
+	const [open, setOpen] = useState(false);
+	return (
+		<div className="section-link">
+			<Link href={href}>
+				{section}
+				{subsections && (
+					<i
+						className="fa-solid fa-chevron-down"
+						onClick={e => {
+							e.preventDefault();
+							setOpen(!open);
+						}}
+						data-open={open}
+					/>
+				)}
+			</Link>
+			{subsections && (
+				<div className="dropdown">
+					{subsections.map((subsection, i) => (
+						<Link key={i} href={subsection.href}>
+							{subsection.name}
+						</Link>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}
 
-function SectionLink({ href, name: section, subsections, isMobile }: { href: string; name: string; subsections?: Subsection[]; isMobile: boolean }) {
+function SectionLinkA({ href, name: section, subsections, isMobile }: { href: string; name: string; subsections?: Subsection[]; isMobile: boolean }) {
 	const [open, setOpen] = useState(false);
 	const hasDropdown = Boolean(subsections?.length);
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -43,7 +43,7 @@ function SectionLink({ href, name: section, subsections }: { href: string; name:
 			<div className="section-button">
 				<Link href={href}>{section}</Link>
 				{ subsections && <div className="bar-vertical"/> }
-				{ subsections && <span><i className="fa-solid fa-chevron-down" data-open={open} onClick={e => { e.preventDefault(); setOpen(!open); }}/></span> }
+				{ subsections && <span onClick={e => { e.preventDefault(); setOpen(!open); }}><i className="fa-solid fa-chevron-down" data-open={open}/></span> }
 			</div>
 			{/* <Link href={href} onClick={e => { e.preventDefault(); setOpen(!open); }}>
 				{section}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -43,7 +43,7 @@ function SectionLink({ href, name: section, subsections }: { href: string; name:
 			<div className="section-button">
 				<Link href={href}>{section}</Link>
 				{ subsections && <div className="bar-vertical"/> }
-				{ subsections && <i className="fa-solid fa-chevron-down" data-open={open} onClick={e => { e.preventDefault(); setOpen(!open); }}/> }
+				{ subsections && <span><i className="fa-solid fa-chevron-down" data-open={open} onClick={e => { e.preventDefault(); setOpen(!open); }}/></span> }
 			</div>
 			{/* <Link href={href} onClick={e => { e.preventDefault(); setOpen(!open); }}>
 				{section}

--- a/pages/articles/[year]/[month]/[cat]/article.module.scss
+++ b/pages/articles/[year]/[month]/[cat]/article.module.scss
@@ -48,14 +48,7 @@ section.content {
 }
 
 .return-to-category-container {
-	/* Keep at top; don't follow scroll */
-	position: relative;
-	top: 0;
-
-	@media screen and (max-width: 970px) {
-		position: relative;
-		top: 0;
-	}
+	position:relative;
 }
 
 a.return-to-category {
@@ -79,7 +72,7 @@ a.return-to-category {
 	// For the up-right arrow on the button (fa free doesn't have up-right :( )
 	i:global(.fa-arrow-up) {
 		transform: rotate(45deg);
-		transition: transform ease-in;
+		transition: transform ease-in 0.2s;
 	}
 
 	&:active {
@@ -160,14 +153,14 @@ a.return-to-category {
 	.main-article:not(h1, h2, h3, blockquote p)::first-letter {
 		initial-letter: 2;
 		-webkit-initial-letter:2;
-		margin-right: 5px;
+		margin-right: 2px;
 	}
 
-	// section.content p {
-	// 	font-size: 1.05rem;
-	// 	line-height: 1.75;
-	// 	word-spacing: 0.015em;
-	// }
+	section.content p {
+		font-size: 1.1rem;
+		line-height: 1.5;
+		word-spacing: 0.05ch;
+	}
 
 	// .main-article a {
 	// 	font-size: 1.05rem;

--- a/pages/articles/[year]/[month]/[cat]/article.module.scss
+++ b/pages/articles/[year]/[month]/[cat]/article.module.scss
@@ -129,49 +129,49 @@ a.return-to-category {
 	}
 }
 
-// @media screen and (max-width: 900px) {
-// 	section.content {
-// 		margin-top: 3rem;
-// 		max-width: 100%;
-// 		width: 100%;
-// 		margin-inline: 0;
-// 		padding-inline: clamp(1rem, 4vw, 1.5rem);
-// 	}
+@media screen and (max-width: 900px) {
+	section.content {
+		// margin-top: 3rem;
+		// max-width: 100%;
+		// width: 100%;
+		// margin-inline: 0;
+		padding-inline: 1rem;
+	}
 
-// 	section.content .titleblock {
-// 		text-align: left;
+	section.content .titleblock {
+		text-align: left;
 
-// 		h1 {
-// 			font-size: clamp(2rem, 6.5vw, 2.6rem);
-// 			line-height: 1.2;
-// 			margin-bottom: 0.75rem;
-// 		}
+		h1 {
+			font-size: clamp(2rem, 6.5vw, 2.6rem);
+			line-height: 1.2;
+			margin-bottom: 0.75rem;
+		}
 
-// 		.date {
-// 			font-size: 0.95rem;
-// 		}
+		.date {
+			font-size: 0.95rem;
+		}
 
-// 		.authors {
-// 			font-size: 1rem;
-// 		}
-// 	}
+		.authors {
+			font-size: 1rem;
+		}
+	}
 
-// 	.main-article:not(h1, h2, h3, blockquote p)::first-letter {
-// 		initial-letter: inherit;
-// 		margin-right: 0;
-// 	}
+	// .main-article:not(h1, h2, h3, blockquote p)::first-letter {
+	// 	initial-letter: inherit;
+	// 	margin-right: 0;
+	// }
 
-// 	section.content p {
-// 		font-size: 1.05rem;
-// 		line-height: 1.75;
-// 		word-spacing: 0.015em;
-// 	}
+	// section.content p {
+	// 	font-size: 1.05rem;
+	// 	line-height: 1.75;
+	// 	word-spacing: 0.015em;
+	// }
 
-// 	.main-article a {
-// 		font-size: 1.05rem;
-// 	}
+	// .main-article a {
+	// 	font-size: 1.05rem;
+	// }
 
-// 	.main-article blockquote p {
-// 		font-size: 1.2rem !important;
-// 	}
-// }
+	// .main-article blockquote p {
+	// 	font-size: 1.2rem !important;
+	// }
+}

--- a/pages/articles/[year]/[month]/[cat]/article.module.scss
+++ b/pages/articles/[year]/[month]/[cat]/article.module.scss
@@ -23,6 +23,7 @@ section.content .titleblock {
 	initial-letter: 3;
 	-webkit-initial-letter: 1;
 	margin-right: 10px;
+	-webkit-margin-right:0;
 }
 
 section.content {

--- a/pages/articles/[year]/[month]/[cat]/article.module.scss
+++ b/pages/articles/[year]/[month]/[cat]/article.module.scss
@@ -129,49 +129,49 @@ a.return-to-category {
 	}
 }
 
-@media screen and (max-width: 900px) {
-	section.content {
-		margin-top: 3rem;
-		max-width: 100%;
-		width: 100%;
-		margin-inline: 0;
-		padding-inline: clamp(1rem, 4vw, 1.5rem);
-	}
+// @media screen and (max-width: 900px) {
+// 	section.content {
+// 		margin-top: 3rem;
+// 		max-width: 100%;
+// 		width: 100%;
+// 		margin-inline: 0;
+// 		padding-inline: clamp(1rem, 4vw, 1.5rem);
+// 	}
 
-	section.content .titleblock {
-		text-align: left;
+// 	section.content .titleblock {
+// 		text-align: left;
 
-		h1 {
-			font-size: clamp(2rem, 6.5vw, 2.6rem);
-			line-height: 1.2;
-			margin-bottom: 0.75rem;
-		}
+// 		h1 {
+// 			font-size: clamp(2rem, 6.5vw, 2.6rem);
+// 			line-height: 1.2;
+// 			margin-bottom: 0.75rem;
+// 		}
 
-		.date {
-			font-size: 0.95rem;
-		}
+// 		.date {
+// 			font-size: 0.95rem;
+// 		}
 
-		.authors {
-			font-size: 1rem;
-		}
-	}
+// 		.authors {
+// 			font-size: 1rem;
+// 		}
+// 	}
 
-	.main-article:not(h1, h2, h3, blockquote p)::first-letter {
-		initial-letter: inherit;
-		margin-right: 0;
-	}
+// 	.main-article:not(h1, h2, h3, blockquote p)::first-letter {
+// 		initial-letter: inherit;
+// 		margin-right: 0;
+// 	}
 
-	section.content p {
-		font-size: 1.05rem;
-		line-height: 1.75;
-		word-spacing: 0.015em;
-	}
+// 	section.content p {
+// 		font-size: 1.05rem;
+// 		line-height: 1.75;
+// 		word-spacing: 0.015em;
+// 	}
 
-	.main-article a {
-		font-size: 1.05rem;
-	}
+// 	.main-article a {
+// 		font-size: 1.05rem;
+// 	}
 
-	.main-article blockquote p {
-		font-size: 1.2rem !important;
-	}
-}
+// 	.main-article blockquote p {
+// 		font-size: 1.2rem !important;
+// 	}
+// }

--- a/pages/articles/[year]/[month]/[cat]/article.module.scss
+++ b/pages/articles/[year]/[month]/[cat]/article.module.scss
@@ -125,10 +125,6 @@ a.return-to-category {
 
 @media screen and (max-width: 900px) {
 	section.content {
-		// margin-top: 3rem;
-		// max-width: 100%;
-		// width: 100%;
-		// margin-inline: 0;
 		padding-inline: 1rem;
 	}
 
@@ -162,9 +158,9 @@ a.return-to-category {
 		word-spacing: 0.05ch;
 	}
 
-	// .main-article a {
-	// 	font-size: 1.05rem;
-	// }
+	.main-article a {
+		font-size: 1em;
+	}
 
 	// .main-article blockquote p {
 	// 	font-size: 1.2rem !important;

--- a/pages/articles/[year]/[month]/[cat]/article.module.scss
+++ b/pages/articles/[year]/[month]/[cat]/article.module.scss
@@ -21,6 +21,7 @@ section.content .titleblock {
 
 .main-article:not(h1, h2, h3, blockquote p)::first-letter {
 	initial-letter: 3;
+	-webkit-initial-letter: 1;
 	margin-right: 10px;
 }
 

--- a/pages/articles/[year]/[month]/[cat]/article.module.scss
+++ b/pages/articles/[year]/[month]/[cat]/article.module.scss
@@ -21,9 +21,8 @@ section.content .titleblock {
 
 .main-article:not(h1, h2, h3, blockquote p)::first-letter {
 	initial-letter: 3;
-	-webkit-initial-letter: 1;
+	-webkit-initial-letter: 3;
 	margin-right: 10px;
-	-webkit-margin-right:0;
 }
 
 section.content {

--- a/pages/articles/[year]/[month]/[cat]/article.module.scss
+++ b/pages/articles/[year]/[month]/[cat]/article.module.scss
@@ -160,7 +160,7 @@ a.return-to-category {
 	.main-article:not(h1, h2, h3, blockquote p)::first-letter {
 		initial-letter: 2;
 		-webkit-initial-letter:2;
-		margin-right: 0;
+		margin-right: 5px;
 	}
 
 	// section.content p {

--- a/pages/articles/[year]/[month]/[cat]/article.module.scss
+++ b/pages/articles/[year]/[month]/[cat]/article.module.scss
@@ -157,10 +157,11 @@ a.return-to-category {
 		}
 	}
 
-	// .main-article:not(h1, h2, h3, blockquote p)::first-letter {
-	// 	initial-letter: inherit;
-	// 	margin-right: 0;
-	// }
+	.main-article:not(h1, h2, h3, blockquote p)::first-letter {
+		initial-letter: 2;
+		-webkit-initial-letter:2;
+		margin-right: 0;
+	}
 
 	// section.content p {
 	// 	font-size: 1.05rem;

--- a/pages/nav.scss
+++ b/pages/nav.scss
@@ -378,14 +378,10 @@ nav {
 				overflow: auto;
 				color-scheme: dark;
 
-				.section-link > a {
+				.section-link > .section-button {
 					font-weight: 600;
 					display: flex;
 					justify-content: space-between;
-
-					i {
-						width: 24px;
-					}
 				}
 
 				a {
@@ -395,6 +391,14 @@ nav {
 					&:hover {
 						background: white;
 						color: var(--accent-dark);
+					}
+
+					i {
+						width: 24px;
+						&:hover {
+							background: white;
+							color: var(--accent-dark);
+						}
 					}
 				}
 

--- a/pages/nav.scss
+++ b/pages/nav.scss
@@ -383,15 +383,24 @@ nav {
 					justify-content: space-between;
 					align-items:center;
 					padding:0;
+					border-bottom: #ccc solid 0.5px;
 					// padding: 1rem 0.5rem;
+
+					span{
+						&:hover {
+							background:white;
+							cursor: pointer;
+						}
+						width: 24px;
+						padding: 1rem 1rem;
+						overflow:hidden;
+					}
 
 					i {
 						width: 24px;
-						padding: 1rem 1rem;
 						&:hover {
-							background: white;
+							// background: white;
 							color: var(--accent-dark);
-							cursor: pointer;
 						}
 					}
 					>a {
@@ -399,7 +408,7 @@ nav {
 					}
 
 					div.bar-vertical {
-						width:1px;
+						width:0.5px;
 						height:2rem;
 						background:#ccc;
 						margin-inline:0.25rem;

--- a/pages/nav.scss
+++ b/pages/nav.scss
@@ -98,7 +98,6 @@ nav {
 		}
 
 		i {
-			margin-left: 0.5ch;
 			font-size: 0.75rem;
 			line-height: 1.5rem;
 			width: 1rem;
@@ -382,6 +381,7 @@ nav {
 					font-weight: 600;
 					display: flex;
 					justify-content: space-between;
+					align-items:center;
 					padding:0;
 					// padding: 1rem 0.5rem;
 
@@ -396,6 +396,13 @@ nav {
 					}
 					>a {
 						padding: 1rem 0.5rem;
+					}
+
+					div.bar-vertical {
+						width:1px;
+						height:2rem;
+						background:#ccc;
+						margin-inline:0.25rem;
 					}
 				}
 

--- a/pages/nav.scss
+++ b/pages/nav.scss
@@ -406,10 +406,9 @@ nav {
 						font-weight:600;
 					}
 					>a {
-						padding: 1rem 0.5rem;
+						padding: 1.125rem 0.5rem;
 						font-weight:600;
 						height:100%;
-						font-size:1.25rem;
 					}
 
 					div.bar-vertical {

--- a/pages/nav.scss
+++ b/pages/nav.scss
@@ -382,12 +382,12 @@ nav {
 					font-weight: 600;
 					display: flex;
 					justify-content: space-between;
-					padding:none;
+					padding:0;
 					// padding: 1rem 0.5rem;
 
 					i {
 						width: 24px;
-						padding: 1rem 0.5rem;
+						padding: 1rem 1rem;
 						&:hover {
 							background: white;
 							color: var(--accent-dark);

--- a/pages/nav.scss
+++ b/pages/nav.scss
@@ -69,12 +69,12 @@ nav {
 	.section-link {
 		position: relative;
 
-		a {
+		.section-button {
 			display: block;
 		}
 
 		// Top-level categories
-		> a {
+		> .section-button {
 			padding: 1rem 0.5rem;
 			display: block;
 			position: relative;
@@ -82,7 +82,7 @@ nav {
 		}
 
 		// The underline on top-level categories
-		> a::before {
+		>.section-button>a::before {
 			content: "";
 			display: block;
 			position: absolute;
@@ -94,11 +94,11 @@ nav {
 			transition: width 0.25s;
 		}
 
-		> a:has(i)::before {
-			right: calc(0.5rem + 2ch);
-		}
+		// > a:has(i)::before {
+		// 	right: calc(0.5rem + 2ch);
+		// }
 
-		> a > i {
+		i {
 			margin-left: 0.5ch;
 			font-size: 0.75rem;
 			line-height: 1.5rem;
@@ -111,6 +111,7 @@ nav {
 		}
 
 		@media screen and (min-width: $mobile) {
+			// i.e. wide aah view
 			&:hover {
 				@keyframes fade-in {
 					0% {
@@ -127,33 +128,33 @@ nav {
 					display: block;
 				}
 
-				> a::before {
+				>.section-button>a::before {
 					left: 0.5rem;
 					width: calc(100% - 1rem);
 				}
 
-				> a:has(i)::before {
-					width: calc(100% - 1rem - 2ch);
-				}
+				// >a:has(i)::before {
+				// 	width: calc(100% - 1rem - 2ch);
+				// }
 
-				> a > i {
+				i {
 					transform: rotate(-180deg);
 				}
 			}
 		}
 
 		@media screen and (max-width: 1064px) and (min-width: 970px) {
-			> a > i {
+			i {
 				display: none;
 			}
 
-			> a:has(i)::before {
-				right: 0.5rem;
-			}
+			// > a:has(i)::before {
+			// 	right: 0.5rem;
+			// }
 
-			&:hover > a:has(i)::before {
-				width: calc(100% - 1rem);
-			}
+			// &:hover > a:has(i)::before {
+			// 	width: calc(100% - 1rem);
+			// }
 		}
 	}
 
@@ -382,6 +383,10 @@ nav {
 					font-weight: 600;
 					display: flex;
 					justify-content: space-between;
+
+					i {
+						width: 24px;
+					}
 				}
 
 				a {
@@ -391,14 +396,6 @@ nav {
 					&:hover {
 						background: white;
 						color: var(--accent-dark);
-					}
-
-					i {
-						width: 24px;
-						&:hover {
-							background: white;
-							color: var(--accent-dark);
-						}
 					}
 				}
 

--- a/pages/nav.scss
+++ b/pages/nav.scss
@@ -93,7 +93,7 @@ nav {
 			transition: width 0.25s;
 		}
 
-		:has(i)> a::before {
+		>.section-button:has(i)> a::before {
 			right: calc(0.5rem + 2ch);
 		}
 

--- a/pages/nav.scss
+++ b/pages/nav.scss
@@ -148,11 +148,11 @@ nav {
 				display: none;
 			}
 
-			:has(i)>a::before {
+			>.section-button:has(i)>a::before {
 				right: 0.5rem;
 			}
 
-			&:has(i):hover>a::before {
+			>.section-button:has(i):hover>a::before {
 				width: calc(100% - 1rem);
 			}
 		}

--- a/pages/nav.scss
+++ b/pages/nav.scss
@@ -382,14 +382,20 @@ nav {
 					font-weight: 600;
 					display: flex;
 					justify-content: space-between;
+					padding:none;
+					// padding: 1rem 0.5rem;
 
 					i {
 						width: 24px;
+						padding: 1rem 0.5rem;
 						&:hover {
 							background: white;
 							color: var(--accent-dark);
 							cursor: pointer;
 						}
+					}
+					>a {
+						padding: 1rem 0.5rem;
 					}
 				}
 

--- a/pages/nav.scss
+++ b/pages/nav.scss
@@ -391,6 +391,9 @@ nav {
 						&:hover {
 							background:white;
 							cursor: pointer;
+							i {
+								color: var(--accent-dark);
+							}
 						}
 						width: 24px;
 						padding: 1rem 1rem;
@@ -401,10 +404,6 @@ nav {
 						width: 24px;
 						color: var(--fg-col);
 						font-weight:600;
-						&:hover {
-							// background: white;
-							color: var(--accent-dark);
-						}
 					}
 					>a {
 						padding: 1rem 0.5rem;

--- a/pages/nav.scss
+++ b/pages/nav.scss
@@ -388,6 +388,7 @@ nav {
 						&:hover {
 							background: white;
 							color: var(--accent-dark);
+							cursor: pointer;
 						}
 					}
 				}
@@ -395,7 +396,7 @@ nav {
 				a {
 					font-family: var(--font-serif-header);
 					text-align: left;
-
+					flex-grow:1;
 					&:hover {
 						background: white;
 						color: var(--accent-dark);

--- a/pages/nav.scss
+++ b/pages/nav.scss
@@ -147,11 +147,11 @@ nav {
 				display: none;
 			}
 
-			> a:has(i)::before {
+			:has(i)>a::before {
 				right: 0.5rem;
 			}
 
-			&:hover > a:has(i)::before {
+			&:has(i):hover>a::before {
 				width: calc(100% - 1rem);
 			}
 		}
@@ -385,6 +385,10 @@ nav {
 
 					i {
 						width: 24px;
+						&:hover {
+							background: white;
+							color: var(--accent-dark);
+						}
 					}
 				}
 

--- a/pages/nav.scss
+++ b/pages/nav.scss
@@ -70,7 +70,7 @@ nav {
 		position: relative;
 
 		.section-button {
-			display: block;
+			display: flex;
 		}
 
 		// Top-level categories
@@ -97,7 +97,7 @@ nav {
 			transition: width 0.25s;
 		}
 
-		> a:has(i)::before {
+		:has(i) > a::before {
 			right: calc(0.5rem + 2ch);
 		}
 

--- a/pages/nav.scss
+++ b/pages/nav.scss
@@ -79,6 +79,9 @@ nav {
 			display: block;
 			position: relative;
 			color: var(--text-light);
+			>a {
+				color: var(--text-light);
+			}
 		}
 
 		// The underline on top-level categories
@@ -94,9 +97,9 @@ nav {
 			transition: width 0.25s;
 		}
 
-		// > a:has(i)::before {
-		// 	right: calc(0.5rem + 2ch);
-		// }
+		> a:has(i)::before {
+			right: calc(0.5rem + 2ch);
+		}
 
 		i {
 			margin-left: 0.5ch;
@@ -133,9 +136,9 @@ nav {
 					width: calc(100% - 1rem);
 				}
 
-				// >a:has(i)::before {
-				// 	width: calc(100% - 1rem - 2ch);
-				// }
+				>a:has(i)::before {
+					width: calc(100% - 1rem - 2ch);
+				}
 
 				i {
 					transform: rotate(-180deg);
@@ -148,13 +151,13 @@ nav {
 				display: none;
 			}
 
-			// > a:has(i)::before {
-			// 	right: 0.5rem;
-			// }
+			> a:has(i)::before {
+				right: 0.5rem;
+			}
 
-			// &:hover > a:has(i)::before {
-			// 	width: calc(100% - 1rem);
-			// }
+			&:hover > a:has(i)::before {
+				width: calc(100% - 1rem);
+			}
 		}
 	}
 

--- a/pages/nav.scss
+++ b/pages/nav.scss
@@ -133,7 +133,7 @@ nav {
 					width: calc(100% - 1rem);
 				}
 
-				>a:has(i)::before {
+				>.section-button:has(i)>a::before {
 					width: calc(100% - 1rem - 2ch);
 				}
 

--- a/pages/nav.scss
+++ b/pages/nav.scss
@@ -73,6 +73,8 @@ nav {
 		> .section-button {
 			padding: 1rem 0.5rem;
 			display: flex;
+			align-items: center;
+			gap:0.1rem;
 			position: relative;
 			color: var(--text-light);
 			>a {
@@ -102,7 +104,7 @@ nav {
 			line-height: 1.5rem;
 			width: 1rem;
 			text-align: center;
-
+			color:white;
 			transform: rotate(0deg);
 
 			transition: transform 0.5s;

--- a/pages/nav.scss
+++ b/pages/nav.scss
@@ -376,6 +376,7 @@ nav {
 				padding-inline: 2rem;
 				overflow: auto;
 				color-scheme: dark;
+				padding-top:1rem;
 
 				.section-link > .section-button {
 					font-weight: 600;
@@ -398,6 +399,8 @@ nav {
 
 					i {
 						width: 24px;
+						color: var(--fg-col);
+						font-weight:600;
 						&:hover {
 							// background: white;
 							color: var(--accent-dark);
@@ -405,6 +408,7 @@ nav {
 					}
 					>a {
 						padding: 1rem 0.5rem;
+						font-weight:600;
 					}
 
 					div.bar-vertical {

--- a/pages/nav.scss
+++ b/pages/nav.scss
@@ -406,8 +406,9 @@ nav {
 						font-weight:600;
 					}
 					>a {
-						padding: 1rem 0.5rem;
+						padding: 1rem 0.625rem;
 						font-weight:600;
+						height:100%;
 					}
 
 					div.bar-vertical {

--- a/pages/nav.scss
+++ b/pages/nav.scss
@@ -406,9 +406,10 @@ nav {
 						font-weight:600;
 					}
 					>a {
-						padding: 1rem 0.625rem;
+						padding: 1rem 0.5rem;
 						font-weight:600;
 						height:100%;
+						font-size:1.25rem;
 					}
 
 					div.bar-vertical {

--- a/pages/nav.scss
+++ b/pages/nav.scss
@@ -444,6 +444,7 @@ nav {
 					}
 
 					a {
+						display: block;
 						padding-inline: 1rem;
 						color: #ccc;
 						border: none;

--- a/pages/nav.scss
+++ b/pages/nav.scss
@@ -69,14 +69,10 @@ nav {
 	.section-link {
 		position: relative;
 
-		.section-button {
-			display: flex;
-		}
-
 		// Top-level categories
 		> .section-button {
 			padding: 1rem 0.5rem;
-			display: block;
+			display: flex;
 			position: relative;
 			color: var(--text-light);
 			>a {
@@ -97,7 +93,7 @@ nav {
 			transition: width 0.25s;
 		}
 
-		:has(i) > a::before {
+		:has(i)> a::before {
 			right: calc(0.5rem + 2ch);
 		}
 


### PR DESCRIPTION
OK SO

The styles + logic for the nav was getting _waaaay_ too complicated (maybe im just too dumb for it lol), so I simplified it down and made it a bit more like the original intention. On mobile:
 - Section names divided clearly
 - Clearly separated open dropdown button for applicable sections
 - Little barrier space between them (I'd be down to remove this, just think it improves UI readability/usability a bit

The main benefit here is that we move more styling logic to the CSS, instead of forcing react to re-render. The speed change is tiny, but the readability is like actually kinda fire